### PR TITLE
feat(filters): add clear filters functionality and apply button state

### DIFF
--- a/src/modules/transactions/filters/components/__tests__/filters-drawer.test.tsx
+++ b/src/modules/transactions/filters/components/__tests__/filters-drawer.test.tsx
@@ -26,6 +26,8 @@ vi.mock('../hooks/useFilters', () => ({
     handleChipSelect: vi.fn(),
     handleAmountChange: vi.fn(),
     applyFilters: applyFiltersSpy,
+    isApplyEnabled: false,
+    clearFilters: vi.fn(),
   }),
 }));
 
@@ -239,6 +241,8 @@ describe('FiltersDrawer', () => {
       handleChipSelect: vi.fn(),
       handleAmountChange: vi.fn(),
       applyFilters: applyFiltersSpy, // Use our local spy
+      isApplyEnabled: true,
+      clearFilters: vi.fn(),
     });
 
     render(<FiltersDrawer />);

--- a/src/modules/transactions/filters/components/filters-drawer.tsx
+++ b/src/modules/transactions/filters/components/filters-drawer.tsx
@@ -24,20 +24,23 @@ export const FiltersDrawer = () => {
   const [isOpen, setIsOpen] = useState(false);
 
   const {
-    storeFilters,
     localFilters,
-    currentFilters,
     handleCheckedChange,
     handleDateSelect,
     handleChipSelect,
     handleAmountChange,
     applyFilters,
+    isApplyEnabled,
+    clearFilters,
   } = useFilters();
-  // debug purpose only, remove later
-  console.log({ storeFilters, localFilters, currentFilters });
 
   const handleApplyFilters = () => {
     applyFilters();
+    setIsOpen(false);
+  };
+
+  const handleClearFilters = () => {
+    clearFilters();
     setIsOpen(false);
   };
 
@@ -101,6 +104,8 @@ export const FiltersDrawer = () => {
               <Button
                 variant="link"
                 className="font-light text-primary-blue text-base"
+                disabled={!isApplyEnabled}
+                onClick={handleClearFilters}
                 aria-label="Clear all filters"
                 data-testid="clear-filters-button"
               >
@@ -175,6 +180,7 @@ export const FiltersDrawer = () => {
             <Button
               className="rounded-3xl h-12 text-base"
               onClick={handleApplyFilters}
+              disabled={!isApplyEnabled}
               aria-label="Apply filters and close"
               data-testid="apply-filters-button"
             >

--- a/src/modules/transactions/filters/hooks/useFilters.ts
+++ b/src/modules/transactions/filters/hooks/useFilters.ts
@@ -14,125 +14,129 @@ import { DateRange } from 'react-day-picker';
 
 const MAX_AMOUNT = 2000;
 
+const createInitialFiltersState = (): FiltersLocal => {
+  const initialState: FiltersLocal = {};
+
+  initialState[FilterType.DATE] = {
+    checked: false,
+    dateRange: {
+      from: undefined,
+      to: undefined,
+    },
+  };
+
+  initialState[FilterType.CARD] = {
+    checked: false,
+    options: [
+      {
+        value: 'todas',
+        label: 'Todas',
+        isSelected: false,
+      },
+      // TODO: replace hardcode values with the real data
+      {
+        value: CardValue.VISA,
+        label: 'Visa',
+        isSelected: false,
+      },
+      {
+        value: CardValue.MASTERCARD,
+        label: 'Mastercard',
+        isSelected: false,
+      },
+      {
+        value: CardValue.AMEX,
+        label: 'American Express',
+        isSelected: false,
+      },
+    ],
+  };
+
+  initialState[FilterType.AMOUNT] = {
+    checked: false,
+    range: {
+      min: 0,
+      max: MAX_AMOUNT,
+    },
+    values: {
+      min: 0,
+      max: MAX_AMOUNT,
+    },
+  };
+
+  initialState[FilterType.INSTALLMENTS] = {
+    checked: false,
+    options: [
+      {
+        value: 'todas',
+        label: 'Todas',
+        isSelected: false,
+      },
+      // TODO: replace hardcode values with the real data
+      {
+        value: 1,
+        label: '1',
+        isSelected: false,
+      },
+      {
+        value: 2,
+        label: '2',
+        isSelected: false,
+      },
+      {
+        value: 3,
+        label: '3',
+        isSelected: false,
+      },
+      {
+        value: 6,
+        label: '6',
+        isSelected: false,
+      },
+      {
+        value: 12,
+        label: '12',
+        isSelected: false,
+      },
+    ],
+  };
+
+  initialState[FilterType.PAYMENT_METHOD] = {
+    checked: false,
+    options: [
+      {
+        value: PaymentMethodValue.LINK,
+        label: 'Link de pago',
+        isSelected: false,
+      },
+      {
+        value: PaymentMethodValue.QR,
+        label: 'Codigo QR',
+        isSelected: false,
+      },
+      {
+        value: PaymentMethodValue.MPOS,
+        label: 'MPOS',
+        isSelected: false,
+      },
+      {
+        value: PaymentMethodValue.POSPRO,
+        label: 'POS Pro',
+        isSelected: false,
+      },
+    ],
+  };
+
+  return initialState;
+};
+
 export const useFilters = () => {
   const storeFilters = useFiltersStore(state => state.toApply);
 
   // Local state to use in the UI
-  const [localFilters, setLocalFilters] = useState<FiltersLocal>(() => {
-    const initialState: FiltersLocal = {};
-
-    initialState[FilterType.DATE] = {
-      checked: false,
-      dateRange: {
-        from: undefined,
-        to: undefined,
-      },
-    };
-
-    initialState[FilterType.CARD] = {
-      checked: false,
-      options: [
-        {
-          value: 'todas',
-          label: 'Todas',
-          isSelected: false,
-        },
-        // TODO: replace hardcode values with the real data
-        {
-          value: CardValue.VISA,
-          label: 'Visa',
-          isSelected: false,
-        },
-        {
-          value: CardValue.MASTERCARD,
-          label: 'Mastercard',
-          isSelected: false,
-        },
-        {
-          value: CardValue.AMEX,
-          label: 'American Express',
-          isSelected: false,
-        },
-      ],
-    };
-
-    initialState[FilterType.AMOUNT] = {
-      checked: false,
-      range: {
-        min: 0,
-        max: MAX_AMOUNT,
-      },
-      values: {
-        min: 0,
-        max: MAX_AMOUNT,
-      },
-    };
-
-    initialState[FilterType.INSTALLMENTS] = {
-      checked: false,
-      options: [
-        {
-          value: 'todas',
-          label: 'Todas',
-          isSelected: false,
-        },
-        // TODO: replace hardcode values with the real data
-        {
-          value: 1,
-          label: '1',
-          isSelected: false,
-        },
-        {
-          value: 2,
-          label: '2',
-          isSelected: false,
-        },
-        {
-          value: 3,
-          label: '3',
-          isSelected: false,
-        },
-        {
-          value: 6,
-          label: '6',
-          isSelected: false,
-        },
-        {
-          value: 12,
-          label: '12',
-          isSelected: false,
-        },
-      ],
-    };
-
-    initialState[FilterType.PAYMENT_METHOD] = {
-      checked: false,
-      options: [
-        {
-          value: PaymentMethodValue.LINK,
-          label: 'Link de pago',
-          isSelected: false,
-        },
-        {
-          value: PaymentMethodValue.QR,
-          label: 'Codigo QR',
-          isSelected: false,
-        },
-        {
-          value: PaymentMethodValue.MPOS,
-          label: 'MPOS',
-          isSelected: false,
-        },
-        {
-          value: PaymentMethodValue.POSPRO,
-          label: 'POS Pro',
-          isSelected: false,
-        },
-      ],
-    };
-
-    return initialState;
-  });
+  const [localFilters, setLocalFilters] = useState<FiltersLocal>(() =>
+    createInitialFiltersState(),
+  );
 
   // Intermadiate state to format the local to the store
   const currentFilters = useMemo(() => {
@@ -319,6 +323,24 @@ export const useFilters = () => {
     }
   }, [currentFilters, setFilterValues]);
 
+  const isApplyEnabled = useMemo(() => {
+    for (const values of Object.values(localFilters)) {
+      if (values?.checked) {
+        return true;
+      }
+    }
+    return false;
+  }, [localFilters]);
+
+  const clearFiltersStore = useFiltersStore(state => state.clearFilters);
+  const clearFilters = useCallback(() => {
+    // Reset all local filters to initial state
+    setLocalFilters(createInitialFiltersState());
+
+    // Clear filters in the store
+    clearFiltersStore();
+  }, [clearFiltersStore, setLocalFilters]);
+
   return {
     storeFilters,
     localFilters,
@@ -330,5 +352,7 @@ export const useFilters = () => {
     handleAmountChange,
 
     applyFilters,
+    isApplyEnabled,
+    clearFilters,
   };
 };

--- a/src/modules/transactions/filters/store/filters-store.ts
+++ b/src/modules/transactions/filters/store/filters-store.ts
@@ -8,6 +8,7 @@ export interface FiltersState {
     type: K,
     values: NonNullable<FiltersStore[K]>,
   ) => void;
+  clearFilters: () => void;
 }
 
 export const useFiltersStore = create<FiltersState>()(set => ({
@@ -26,5 +27,16 @@ export const useFiltersStore = create<FiltersState>()(set => ({
         [type]: values,
       },
     }));
+  },
+
+  clearFilters: () => {
+    set(state => {
+      const clearedFilters = Object.keys(state.toApply).reduce((acc, key) => {
+        acc[key as keyof FiltersStore] = [];
+        return acc;
+      }, {} as FiltersStore);
+
+      return { toApply: clearedFilters };
+    });
   },
 }));


### PR DESCRIPTION
Enable the clear filters button to reset all filters to their initial state and disable the apply button when no filters are selected. This improves user experience by providing a clear way to reset filters and ensuring the apply button is only enabled when necessary.