### PR TITLE
feat(transactions): empty state for transaction list

### DIFF
--- a/src/components/icons/icon-empty-search.tsx
+++ b/src/components/icons/icon-empty-search.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { SVGProps } from 'react';
+
+type IconEmptySearchProps = SVGProps<SVGSVGElement>;
+
+const IconEmptySearch: React.FC<IconEmptySearchProps> = props => {
+  return (
+    <svg
+      width="72"
+      height="72"
+      viewBox="0 0 72 72"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M46.55 40C51.12 35.97 54 30.07 54 23.5C54 11.35 44.15 1.5 32 1.5C28.2 1.5 24.62 2.46 21.5 4.16L14 9L39.5 46L46.55 40Z"
+        fill="#B7BFD3"
+        stroke="#B7BFD3"
+        stroke-width="2"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M26 50.5C38.4264 50.5 48.5 40.4264 48.5 28C48.5 15.5736 38.4264 5.5 26 5.5C13.5736 5.5 3.5 15.5736 3.5 28C3.5 40.4264 13.5736 50.5 26 50.5Z"
+        fill="white"
+        stroke="#B7BFD3"
+        stroke-width="2"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M69.287 61C71.571 63.284 71.571 66.9932 69.287 69.287C67.0029 71.571 63.2938 71.571 61 69.287L52.713 61C50.429 58.716 50.429 55.0068 52.713 52.713C54.9971 50.429 58.7062 50.429 61 52.713L69.287 61Z"
+        fill="#B7BFD3"
+        stroke="#B7BFD3"
+        stroke-width="2"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M9.46 22.51C9.46 17.44 11.14 12.76 13.97 9C7.68 12.99 3.5 20.01 3.5 28.01C3.5 40.44 13.57 50.51 26 50.51C33.36 50.51 39.88 46.98 43.99 41.52C40.51 43.73 36.39 45.01 31.96 45.01C19.53 45.01 9.46 34.94 9.46 22.51Z"
+        stroke="#B7BFD3"
+        stroke-width="2"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M48 54C51.3137 54 54 51.3137 54 48C54 44.6863 51.3137 42 48 42C44.6863 42 42 44.6863 42 48C42 51.3137 44.6863 54 48 54Z"
+        fill="white"
+        stroke="#B7BFD3"
+        stroke-width="2"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M62 10C62 7.79 63.79 6 66 6C63.79 6 62 4.21 62 2C62 4.21 60.21 6 58 6C60.21 6 62 7.79 62 10Z"
+        fill="#B7BFD3"
+        stroke="#B7BFD3"
+        stroke-width="2"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default IconEmptySearch;

--- a/src/modules/transactions/components/__tests__/transaction-list.test.tsx
+++ b/src/modules/transactions/components/__tests__/transaction-list.test.tsx
@@ -22,19 +22,6 @@ vi.mock('../transaction-item', () => ({
 }));
 
 describe('TransactionList', () => {
-  it('renders the transaction list with correct heading', () => {
-    render(
-      <TransactionList
-        transactions={mockTransactions}
-        isLoading={false}
-        error={null}
-      />,
-    );
-
-    const heading = screen.getByTestId('transactions-heading');
-    expect(heading.textContent).toBe('Historial de Transacciones');
-  });
-
   it('renders the correct number of transaction items', () => {
     render(
       <TransactionList
@@ -102,9 +89,6 @@ describe('TransactionList', () => {
         error={null}
       />,
     );
-
-    const section = screen.getByTestId('transactions-section');
-    expect(section).toBeDefined();
 
     const list = screen.getByTestId('transactions-list');
     expect(list).toBeDefined();

--- a/src/modules/transactions/components/transaction-list.tsx
+++ b/src/modules/transactions/components/transaction-list.tsx
@@ -3,10 +3,8 @@ import { useMemo } from 'react';
 import { TransactionItem } from './transaction-item';
 import { Transaction } from '../transactions.types';
 
-import IconDownload from '@/components/icons/icon-download';
 import { Skeleton } from '@/components/ui/skeleton';
-
-import { FiltersDrawer } from '../filters/components/filters-drawer';
+import IconEmptySearch from '@/components/icons/icon-empty-search';
 
 interface TransactionListProps {
   transactions: Transaction[];
@@ -32,53 +30,40 @@ export const TransactionList: React.FC<TransactionListProps> = ({
     ));
   }, [transactions]);
 
+  if (isLoading) {
+    return Array.from({ length: 10 }).map((_, index) => (
+      <div key={index} className="flex items-center gap-2 px-2 mb-3">
+        <Skeleton className="w-10 h-10 rounded-2xl" />
+        <Skeleton className="w-full h-10 rounded-full" />
+      </div>
+    ));
+  }
+
   if (error) {
     return <div data-testid="error-state">Error: {error.message}</div>;
   }
 
-  return (
-    <section
-      aria-labelledby="transactions-heading"
-      data-testid="transactions-section"
-    >
-      <div className="flex items-center justify-between">
-        <h2
-          id="transactions-heading"
-          className="pl-2 text-sm font-semibold text-neutral-hard"
-          data-testid="transactions-heading"
-        >
-          Historial de Transacciones
-        </h2>
-        <div className="flex md:gap-2" aria-label="Transaction actions">
-          <div className="w-12 h-12 flex items-center justify-center">
-            <FiltersDrawer />
-          </div>
-          <div className="w-12 h-12 flex items-center justify-center">
-            <button
-              aria-label="Download transactions"
-              className="p-2 rounded-full hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-blue"
-            >
-              <IconDownload aria-hidden="true" />
-            </button>
-          </div>
-        </div>
+  if (transactions.length === 0) {
+    return (
+      <div
+        className="w-xs mx-auto flex flex-col items-center gap-4 py-8 text-center"
+        data-testid="empty-transactions"
+      >
+        <IconEmptySearch />
+        <p className="text-neutral text-sm font-light leading-[140%]!">
+          No hay resultados que mostrar. Podés probar usando los filtros.
+        </p>
       </div>
-      {isLoading ? (
-        Array.from({ length: 10 }).map((_, index) => (
-          <div key={index} className="flex items-center gap-2 px-2 mb-3">
-            <Skeleton className="w-10 h-10 rounded-2xl" />
-            <Skeleton className="w-full h-10 rounded-full" />
-          </div>
-        ))
-      ) : (
-        <ul
-          className="flex flex-col divide-y divide-neutral-border list-none p-0 mt-2 mx-0 mb-0"
-          role="list"
-          data-testid="transactions-list"
-        >
-          {MemoizedTransactions}
-        </ul>
-      )}
-    </section>
+    );
+  }
+
+  return (
+    <ul
+      className="flex flex-col divide-y divide-neutral-border list-none p-0 mt-2 mx-0 mb-0"
+      role="list"
+      data-testid="transactions-list"
+    >
+      {MemoizedTransactions}
+    </ul>
   );
 };

--- a/src/modules/transactions/pages/transactions-summary-page.tsx
+++ b/src/modules/transactions/pages/transactions-summary-page.tsx
@@ -1,6 +1,10 @@
+import IconDownload from '@/components/icons/icon-download';
+
 import { TransaccionTotalPeriod } from '../components/transaction-totals-period';
 import { TransactionList } from '../components/transaction-list';
 import { useTransactions } from '../hooks/useTransactions';
+
+import { FiltersDrawer } from '../filters/components/filters-drawer';
 
 export const TransactionsSummaryPage = () => {
   const {
@@ -24,11 +28,38 @@ export const TransactionsSummaryPage = () => {
         isLoading={isLoading}
         error={error}
       />
-      <TransactionList
-        transactions={transactionsFiltered}
-        isLoading={isLoading}
-        error={error}
-      />
+      <section
+        aria-labelledby="transactions-heading"
+        data-testid="transactions-section"
+      >
+        <div className="flex items-center justify-between">
+          <h2
+            id="transactions-heading"
+            className="pl-2 text-sm font-semibold text-neutral-hard"
+            data-testid="transactions-heading"
+          >
+            Historial de Transacciones
+          </h2>
+          <div className="flex md:gap-2" aria-label="Transaction actions">
+            <div className="w-12 h-12 flex items-center justify-center">
+              <FiltersDrawer />
+            </div>
+            <div className="w-12 h-12 flex items-center justify-center">
+              <button
+                aria-label="Download transactions"
+                className="p-2 rounded-full hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-blue"
+              >
+                <IconDownload aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+        </div>
+        <TransactionList
+          transactions={transactionsFiltered}
+          isLoading={isLoading}
+          error={error}
+        />
+      </section>
     </main>
   );
 };


### PR DESCRIPTION
The heading and actions (filters and download button) were moved from the transaction-list component to the transactions-summary-page for better component separation and reusability. The transaction-list component was simplified to focus solely on rendering the list of transactions. Additionally, an empty state with a new icon was added to handle cases where no transactions are found.