### PR TITLE
test: add unit tests for useFilters and useTransactions hooks

### DIFF
--- a/src/modules/transactions/filters/hooks/__tests__/useFilters.test.ts
+++ b/src/modules/transactions/filters/hooks/__tests__/useFilters.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useFilters } from '../useFilters';
+import { FilterType } from '../../filters.types';
+import {
+  CardValue,
+  PaymentMethodValue,
+} from '@/modules/transactions/transactions.types';
+import * as filtersStoreModule from '../../store/filters-store';
+
+// Mock the filters store
+vi.mock('../store/filters-store', () => {
+  return {
+    useFiltersStore: vi.fn().mockImplementation(selector => {
+      const state = {
+        toApply: {
+          [FilterType.DATE]: [],
+          [FilterType.CARD]: [],
+          [FilterType.AMOUNT]: [],
+          [FilterType.INSTALLMENTS]: [],
+          [FilterType.PAYMENT_METHOD]: [],
+        },
+        setFilterValues: vi.fn(),
+        clearFilters: vi.fn(),
+      };
+
+      return selector(state);
+    }),
+  };
+});
+
+describe('useFilters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('initializes with default filter values', () => {
+    const { result } = renderHook(() => useFilters());
+
+    // Check that all filters exist and are initialized properly
+    expect(result.current.localFilters[FilterType.DATE]).toBeDefined();
+    expect(result.current.localFilters[FilterType.DATE]?.checked).toBe(false);
+
+    expect(result.current.localFilters[FilterType.CARD]).toBeDefined();
+    expect(result.current.localFilters[FilterType.CARD]?.checked).toBe(false);
+
+    expect(result.current.localFilters[FilterType.AMOUNT]).toBeDefined();
+    expect(result.current.localFilters[FilterType.AMOUNT]?.checked).toBe(false);
+
+    expect(result.current.localFilters[FilterType.INSTALLMENTS]).toBeDefined();
+    expect(result.current.localFilters[FilterType.INSTALLMENTS]?.checked).toBe(
+      false,
+    );
+
+    expect(
+      result.current.localFilters[FilterType.PAYMENT_METHOD],
+    ).toBeDefined();
+    expect(
+      result.current.localFilters[FilterType.PAYMENT_METHOD]?.checked,
+    ).toBe(false);
+
+    // Verify that no filters are enabled
+    expect(result.current.isApplyEnabled).toBe(false);
+  });
+
+  it('toggles filter checked state correctly', () => {
+    const { result } = renderHook(() => useFilters());
+
+    // Initially all filters should be unchecked
+    expect(result.current.localFilters[FilterType.CARD]?.checked).toBe(false);
+
+    // Toggle the card filter on
+    act(() => {
+      result.current.handleCheckedChange(FilterType.CARD, true);
+    });
+
+    // Verify card filter is now checked
+    expect(result.current.localFilters[FilterType.CARD]?.checked).toBe(true);
+
+    // Verify that isApplyEnabled is now true
+    expect(result.current.isApplyEnabled).toBe(true);
+
+    // Verify other filters remained unchanged
+    expect(result.current.localFilters[FilterType.DATE]?.checked).toBe(false);
+  });
+
+  it('selects and deselects chip options correctly', () => {
+    const { result } = renderHook(() => useFilters());
+
+    // First enable the card filter
+    act(() => {
+      result.current.handleCheckedChange(FilterType.CARD, true);
+    });
+
+    // Now select the 'todas' option that we know exists
+    act(() => {
+      result.current.handleChipSelect(FilterType.CARD, 'todas');
+    });
+
+    // Check if the 'todas' option is now selected
+    const updatedOptions =
+      result.current.localFilters[FilterType.CARD]?.options;
+    const todasOption = updatedOptions?.find(opt => opt.value === 'todas');
+
+    expect(todasOption?.isSelected).toBe(true);
+
+    // Now deselect it
+    act(() => {
+      result.current.handleChipSelect(FilterType.CARD, 'todas');
+    });
+
+    // Check if it's deselected
+    const finalOptions = result.current.localFilters[FilterType.CARD]?.options;
+    const finalTodasOption = finalOptions?.find(opt => opt.value === 'todas');
+
+    expect(finalTodasOption?.isSelected).toBe(false);
+  });
+
+  it('applies filters correctly to the store', () => {
+    // Create a mock for setFilterValues
+    const setFilterValuesMock = vi.fn();
+
+    // Create a spy on the actual imported module
+    const useFiltersStoreSpy = vi.spyOn(filtersStoreModule, 'useFiltersStore');
+
+    // Update the implementation for this test
+    useFiltersStoreSpy.mockImplementation(selector => {
+      const state = {
+        toApply: {
+          [FilterType.DATE]: [],
+          [FilterType.CARD]: [],
+          [FilterType.AMOUNT]: [],
+          [FilterType.INSTALLMENTS]: [],
+          [FilterType.PAYMENT_METHOD]: [],
+        },
+        setFilterValues: setFilterValuesMock,
+        clearFilters: vi.fn(),
+      };
+
+      return selector(state);
+    });
+
+    const { result } = renderHook(() => useFilters());
+
+    // Set up a filter scenario
+    act(() => {
+      // Enable card filter
+      result.current.handleCheckedChange(FilterType.CARD, true);
+
+      // Select the 'todas' option that we know exists
+      result.current.handleChipSelect(FilterType.CARD, 'todas');
+    });
+
+    // Apply the filters
+    act(() => {
+      result.current.applyFilters();
+    });
+
+    // Verify setFilterValues was called
+    expect(setFilterValuesMock).toHaveBeenCalled();
+  });
+
+  it('clears all filters correctly', () => {
+    const { result } = renderHook(() => useFilters());
+
+    // Set up some filters
+    act(() => {
+      result.current.handleCheckedChange(FilterType.CARD, true);
+      result.current.handleChipSelect(FilterType.CARD, CardValue.VISA);
+
+      result.current.handleCheckedChange(FilterType.PAYMENT_METHOD, true);
+      result.current.handleChipSelect(
+        FilterType.PAYMENT_METHOD,
+        PaymentMethodValue.LINK,
+      );
+    });
+
+    // Verify filters are applied
+    expect(result.current.isApplyEnabled).toBe(true);
+
+    // Clear all filters
+    act(() => {
+      result.current.clearFilters();
+    });
+
+    // Verify all filters are reset
+    expect(result.current.localFilters[FilterType.CARD]?.checked).toBe(false);
+    expect(
+      result.current.localFilters[FilterType.PAYMENT_METHOD]?.checked,
+    ).toBe(false);
+
+    // Verify no filters are selected
+    const cardOptions = result.current.localFilters[FilterType.CARD]?.options;
+    expect(cardOptions?.some(option => option.isSelected)).toBe(false);
+
+    // Verify apply is disabled
+    expect(result.current.isApplyEnabled).toBe(false);
+  });
+});

--- a/src/modules/transactions/hooks/__tests__/useTransactions.test.ts
+++ b/src/modules/transactions/hooks/__tests__/useTransactions.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { Periods } from '../../transactions.types';
+import { useTransactions } from '../useTransactions';
+import * as useQueryTransactionsModule from '../useQueryTransactions';
+import * as transactionsStoreModule from '../../store/transactions-store';
+import * as filtersStoreModule from '../../filters/store/filters-store';
+import { FilterType } from '../../filters/filters.types';
+import { CardValue, PaymentMethodValue } from '../../transactions.types';
+
+// Create mock transactions with deliberately different dates
+const createMockTransactions = () => {
+  // Create dates for today, yesterday, and last month
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const lastMonth = new Date(today);
+  lastMonth.setMonth(lastMonth.getMonth() - 1);
+  
+  return [
+    {
+      id: '1',
+      amount: 100,
+      createdAt: today.toISOString(), // Today's transaction - for DAILY
+      paymentMethod: PaymentMethodValue.LINK,
+      card: CardValue.VISA,
+      installments: 1,
+      updatedAt: today.toISOString()
+    },
+    {
+      id: '2',
+      amount: 200,
+      createdAt: yesterday.toISOString(), // Recent transaction - for WEEKLY
+      paymentMethod: PaymentMethodValue.MPOS,
+      card: CardValue.MASTERCARD,
+      installments: 3,
+      updatedAt: yesterday.toISOString()
+    },
+    {
+      id: '3',
+      amount: 500,
+      createdAt: lastMonth.toISOString(), // Old transaction - for MONTHLY
+      paymentMethod: PaymentMethodValue.QR,
+      card: CardValue.AMEX,
+      installments: 6,
+      updatedAt: lastMonth.toISOString()
+    }
+  ];
+};
+
+describe('useTransactions', () => {
+let mockTransactions: ReturnType<typeof createMockTransactions>;
+
+  beforeEach(() => {
+    // Reset all mocks before each test
+    vi.resetAllMocks();
+
+    mockTransactions = createMockTransactions();
+
+    // Set up our mocks with default implementations
+    vi.spyOn(
+      useQueryTransactionsModule,
+      'useQueryTransactions',
+    ).mockReturnValue({
+      data: {
+        transactions: mockTransactions,
+        metadata: { paymentMethods: [], cards: [] },
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    vi.spyOn(
+      transactionsStoreModule,
+      'useTransactionsStore',
+    ).mockImplementation(selector => {
+      const state = {
+        transactions: mockTransactions,
+        paymentMethods: [],
+        cards: [],
+        isInitialized: true,
+        setAllData: vi.fn(),
+        getAllTransactions: () => mockTransactions,
+        getPaymentMethods: () => [],
+        getCards: () => [],
+      };
+      return selector(state);
+    });
+
+    vi.spyOn(filtersStoreModule, 'useFiltersStore').mockImplementation(
+      selector => {
+        const state = {
+          toApply: {
+            [FilterType.DATE]: [],
+            [FilterType.CARD]: [],
+            [FilterType.AMOUNT]: [],
+            [FilterType.INSTALLMENTS]: [],
+            [FilterType.PAYMENT_METHOD]: [],
+          },
+        };
+        return selector({
+          ...state,
+          setFilterValues: vi.fn(),
+          clearFilters: vi.fn(),
+        });
+      },
+    );
+  });
+
+  it('initializes with correct default values', () => {
+    const { result } = renderHook(() => useTransactions());
+
+    // Check initial values
+    expect(result.current.transactions).toEqual(mockTransactions);
+    expect(result.current.transactionsFiltered).toEqual(mockTransactions);
+    expect(result.current.activePeriod).toBe(Periods.WEEKLY);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('allows changing the active period', () => {
+    const { result } = renderHook(() => useTransactions());
+
+    // Initial period should be WEEKLY
+    expect(result.current.activePeriod).toBe(Periods.WEEKLY);
+
+    // Change to daily
+    act(() => {
+      result.current.setActivePeriod(Periods.DAILY);
+    });
+
+    // Period should now be DAILY
+    expect(result.current.activePeriod).toBe(Periods.DAILY);
+
+    // Change to monthly
+    act(() => {
+      result.current.setActivePeriod(Periods.MONTHLY);
+    });
+
+    // Period should now be MONTHLY
+    expect(result.current.activePeriod).toBe(Periods.MONTHLY);
+  });
+
+  it('updates totalAmount when changing period', () => {
+    const { result } = renderHook(() => useTransactions());
+    
+    // Store the initial total amount (WEEKLY)
+    const initialAmount = result.current.totalAmount;
+    
+    // Change to DAILY
+    act(() => {
+      result.current.setActivePeriod(Periods.DAILY);
+    });
+    
+    // Store DAILY amount
+    const dailyAmount = result.current.totalAmount;
+    
+    // Change to MONTHLY
+    act(() => {
+      result.current.setActivePeriod(Periods.MONTHLY);
+    });
+    
+    // Store MONTHLY amount
+    const monthlyAmount = result.current.totalAmount;
+    
+    // Verify that totalAmount changes when period changes
+    // We expect DAILY to only include transactions from today
+    // We expect MONTHLY to include all transactions
+    
+    // Different periods should produce different totals
+    expect(dailyAmount).not.toBe(initialAmount);
+    expect(monthlyAmount).not.toBe(dailyAmount);
+    
+    // Log the values to help with debugging
+    console.log({
+      weekly: initialAmount,
+      daily: dailyAmount, 
+      monthly: monthlyAmount
+    });
+  });
+
+  it('filters transactions based on applied filters', () => {
+    // Mock filter store to return some active filters
+    const filteredMockTransaction = [mockTransactions[0]]; // Just the first transaction
+
+    // Create a mock implementation of filterMethods that returns our filtered result
+    vi.mock('../filters/utils/filters.method', () => ({
+      filterMethods: {
+        [FilterType.CARD]: vi.fn().mockReturnValue(filteredMockTransaction),
+      },
+    }));
+
+    // Update the filter store mock to have active card filters
+    vi.spyOn(filtersStoreModule, 'useFiltersStore').mockImplementation(
+      selector => {
+        const state = {
+          toApply: {
+            [FilterType.CARD]: [CardValue.VISA], // We're filtering for VISA cards
+            [FilterType.DATE]: [],
+            [FilterType.AMOUNT]: [],
+            [FilterType.INSTALLMENTS]: [],
+            [FilterType.PAYMENT_METHOD]: [],
+          },
+        };
+        return selector({
+          ...state,
+          setFilterValues: vi.fn(),
+          clearFilters: vi.fn(),
+        });
+      },
+    );
+
+    const { result } = renderHook(() => useTransactions());
+
+    // Verify transactions have been filtered
+    expect(result.current.transactionsFiltered).toEqual(
+      filteredMockTransaction,
+    );
+    expect(result.current.transactionsFiltered.length).toBe(1);
+  });
+
+  it('handles loading state correctly', () => {
+    // Mock useQueryTransactions to return loading state
+    vi.spyOn(
+      useQueryTransactionsModule,
+      'useQueryTransactions',
+    ).mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    // Mock store to indicate it's not initialized
+    vi.spyOn(
+      transactionsStoreModule,
+      'useTransactionsStore',
+    ).mockImplementation(selector => {
+      const state = {
+        transactions: [],
+        paymentMethods: [],
+        cards: [],
+        isInitialized: false, // Not initialized
+        setAllData: vi.fn(),
+        getAllTransactions: () => [],
+        getPaymentMethods: () => [],
+        getCards: () => [],
+      };
+      return selector(state);
+    });
+
+    const { result } = renderHook(() => useTransactions());
+
+    // Should indicate loading
+    expect(result.current.isLoading).toBe(true);
+    // Should have empty transactions while loading
+    expect(result.current.transactions).toEqual([]);
+  });
+});

--- a/src/modules/transactions/hooks/__tests__/useTransactions.test.ts
+++ b/src/modules/transactions/hooks/__tests__/useTransactions.test.ts
@@ -16,7 +16,7 @@ const createMockTransactions = () => {
   yesterday.setDate(yesterday.getDate() - 1);
   const lastMonth = new Date(today);
   lastMonth.setMonth(lastMonth.getMonth() - 1);
-  
+
   return [
     {
       id: '1',
@@ -25,7 +25,7 @@ const createMockTransactions = () => {
       paymentMethod: PaymentMethodValue.LINK,
       card: CardValue.VISA,
       installments: 1,
-      updatedAt: today.toISOString()
+      updatedAt: today.toISOString(),
     },
     {
       id: '2',
@@ -34,7 +34,7 @@ const createMockTransactions = () => {
       paymentMethod: PaymentMethodValue.MPOS,
       card: CardValue.MASTERCARD,
       installments: 3,
-      updatedAt: yesterday.toISOString()
+      updatedAt: yesterday.toISOString(),
     },
     {
       id: '3',
@@ -43,13 +43,13 @@ const createMockTransactions = () => {
       paymentMethod: PaymentMethodValue.QR,
       card: CardValue.AMEX,
       installments: 6,
-      updatedAt: lastMonth.toISOString()
-    }
+      updatedAt: lastMonth.toISOString(),
+    },
   ];
 };
 
 describe('useTransactions', () => {
-let mockTransactions: ReturnType<typeof createMockTransactions>;
+  let mockTransactions: ReturnType<typeof createMockTransactions>;
 
   beforeEach(() => {
     // Reset all mocks before each test
@@ -144,39 +144,39 @@ let mockTransactions: ReturnType<typeof createMockTransactions>;
 
   it('updates totalAmount when changing period', () => {
     const { result } = renderHook(() => useTransactions());
-    
+
     // Store the initial total amount (WEEKLY)
     const initialAmount = result.current.totalAmount;
-    
+
     // Change to DAILY
     act(() => {
       result.current.setActivePeriod(Periods.DAILY);
     });
-    
+
     // Store DAILY amount
     const dailyAmount = result.current.totalAmount;
-    
+
     // Change to MONTHLY
     act(() => {
       result.current.setActivePeriod(Periods.MONTHLY);
     });
-    
+
     // Store MONTHLY amount
     const monthlyAmount = result.current.totalAmount;
-    
+
     // Verify that totalAmount changes when period changes
     // We expect DAILY to only include transactions from today
     // We expect MONTHLY to include all transactions
-    
+
     // Different periods should produce different totals
     expect(dailyAmount).not.toBe(initialAmount);
     expect(monthlyAmount).not.toBe(dailyAmount);
-    
+
     // Log the values to help with debugging
     console.log({
       weekly: initialAmount,
-      daily: dailyAmount, 
-      monthly: monthlyAmount
+      daily: dailyAmount,
+      monthly: monthlyAmount,
     });
   });
 


### PR DESCRIPTION
Add comprehensive unit tests for the `useFilters` and `useTransactions` hooks to ensure proper initialization, filter application, and state management. The tests cover various scenarios, including filter toggling, chip selection, filter application, and period changes, to validate the hooks' behavior under different conditions.